### PR TITLE
API endpoint для проверки поддержки IPv6 сайтом.

### DIFF
--- a/src/main/java/com/example/accesskeybackend/security/SecurityConfig.java
+++ b/src/main/java/com/example/accesskeybackend/security/SecurityConfig.java
@@ -32,6 +32,7 @@ public class SecurityConfig {
                         auth
                                 .requestMatchers("/api/public/**").permitAll()
                                 .requestMatchers("/actuator/health").permitAll()
+                                .requestMatchers("/api/web/**").permitAll()
                                 .anyRequest().authenticated()
                 )
                 .httpBasic(Customizer.withDefaults())

--- a/src/main/java/com/example/accesskeybackend/template/controller/AccessKeyWebController.java
+++ b/src/main/java/com/example/accesskeybackend/template/controller/AccessKeyWebController.java
@@ -1,0 +1,20 @@
+package com.example.accesskeybackend.template.controller;
+
+import com.example.accesskeybackend.template.service.AccessKeyIpService;
+import lombok.AllArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import java.net.UnknownHostException;
+
+@RestController
+@RequestMapping("/api/web")
+@AllArgsConstructor
+public class AccessKeyWebController {
+    private final AccessKeyIpService accessKeyIpService;
+    @PostMapping("/checkIpv6Support")
+    public ResponseEntity<Boolean> checkIpv6Support(
+            @RequestParam(name = "siteUrl") String siteUrl) throws UnknownHostException{
+        return ResponseEntity.ok().body(accessKeyIpService.checkForIpv6Support(siteUrl));
+    }
+}

--- a/src/main/java/com/example/accesskeybackend/template/service/AccessKeyIpService.java
+++ b/src/main/java/com/example/accesskeybackend/template/service/AccessKeyIpService.java
@@ -1,0 +1,25 @@
+package com.example.accesskeybackend.template.service;
+
+import lombok.AllArgsConstructor;
+import lombok.extern.log4j.Log4j2;
+import org.springframework.stereotype.Service;
+
+import java.net.*;
+
+@Service
+@AllArgsConstructor
+@Log4j2
+public class AccessKeyIpService {
+    public Boolean checkForIpv6Support(String url) throws UnknownHostException {
+        InetAddress inetAddress = InetAddress.getByName(getHostFromUrlString(url));
+        return inetAddress instanceof Inet6Address;
+    }
+
+    private String getHostFromUrlString(String url) {
+        try {
+            return new URL(url).getHost();
+        } catch (MalformedURLException e) {
+            throw new RuntimeException(e);
+        }
+    }
+}


### PR DESCRIPTION
Характеристики этого endpoint'a:
 - публичный
 - /api/web/checkIpv6Support - путь.
 - siteUrl - query parameter. Сюда приходит url сайта который нужно проверить на поддержку IPv6.
 - success - boolean. Такой должен быть ответ, с 200 кодом.

Примечания:
 - siteUrl - принимает как домен в чистом виде, так и полный URI.